### PR TITLE
Updated PointSET, must update insert() for KdTree

### DIFF
--- a/src/KdTree.java
+++ b/src/KdTree.java
@@ -65,6 +65,7 @@ public class KdTree {
         root = insert(root, null, p, true);
     }
 
+    // Have to carry the parent's min and max for point's axis down
     private Node insert(Node x, Node parent, Point2D p, boolean currentAxis) {
         if (x == null) {
             Node newNode = new Node(p, currentAxis);
@@ -304,7 +305,7 @@ public class KdTree {
         // Test Two
         KdTree testTwo = new KdTree();    
         String[] files = new String[1];
-        files[0] = "C:\\Users\\David\\Desktop\\IT_Coding\\Java\\Princeton_Class\\Code\\Inputs\\kdtree\\circle10.txt";
+        files[0] = "C:\\Users\\David\\Desktop\\IT_Coding\\Java\\Princeton_Class\\Code\\Inputs\\kdtree\\input80k.txt";
 
         // for each command-line argument
         for (String filename : files) {
@@ -318,6 +319,7 @@ public class KdTree {
             }
         }
         testTwo.draw();
+        System.out.println(testTwo.size());
     }
 
 }

--- a/src/PointSET.java
+++ b/src/PointSET.java
@@ -76,6 +76,9 @@ public class PointSET {
         if (p == null) {
             throw new IllegalArgumentException();
         }
+        if (bst.isEmpty()) {
+            return null;
+        }
         Point2D closest = bst.first();
         for (Point2D iterPoint : bst) {
             if (iterPoint.distanceTo(p) > closest.distanceTo(p)) {


### PR DESCRIPTION
Updated pointset, must update KdTree insert() to carry down the parent's min/max for axis. Going back up the tree to create the Rect during the insert slows down the insert process too much.